### PR TITLE
Use Meteor's new async collection methods

### DIFF
--- a/simplesigner-jobs.d.ts
+++ b/simplesigner-jobs.d.ts
@@ -27,7 +27,7 @@ declare module 'meteor/simplesigner:jobs' {
 	    private lastPing;
 	    private serverId;
 	    constructor(configuration: DominatorConfiguration);
-	    initialize(): void;
+	    initialize(): Promise<void>;
 	    private upgradeToMaster;
 	    private downgradeToSlave;
 	    private observe;
@@ -45,7 +45,7 @@ declare module 'meteor/simplesigner:jobs' {
 	interface JobConfiguration {
 	    jobCollection: Mongo.Collection<JobDocument>;
 	}
-	declare class Jobs {
+	declare class JobsClass {
 	    private readonly configuration;
 	    collection: Mongo.Collection<JobDocument>;
 	    jobs: JobFunctionMap;
@@ -53,19 +53,19 @@ declare module 'meteor/simplesigner:jobs' {
 	    clear(state?: '*' | JobState | JobState[], jobName?: string, ...parameters: any[]): number;
 	    configure(settings: Partial<Config>): void;
 	    count(jobName: string, ...parameters: any[]): number;
-	    countPending(jobName: string, ...parameters: any[]): number;
-	    execute(jobId: string): void;
-	    findOne(jobName: string, ...parameters: any[]): JobDocument;
+	    countPending(jobName: string, ...parameters: any[]): Promise<number>;
+	    execute(jobId: string): Promise<void>;
+	    findOne(jobName: string, ...parameters: any[]): Promise<JobDocument>;
 	    register(jobFunctionMap: JobFunctionMap): void;
 	    remove(jobId: string): boolean;
-	    replicate(jobId: string, configuration: Partial<JobConfig>): string;
+	    replicate(jobId: string, configuration: Partial<JobConfig>): Promise<string>;
 	    reschedule(jobId: string, configuration: Partial<JobConfig>): void;
-	    run(jobName: string, ...parameters: any[]): false | JobDocument;
+	    run(jobName: string, ...parameters: any[]): Promise<false | JobDocument>;
 	    start(jobArgument?: string | string[]): void;
 	    stop(jobArgument?: string | string[]): void;
 	}
-	declare const instance: Jobs;
-	export { instance as Jobs };
+	declare const Jobs: JobsClass;
+	export { Jobs };
 	import { Config } from './types';
 	declare class Logger {
 	    error: {
@@ -160,7 +160,7 @@ declare module 'meteor/simplesigner:jobs' {
 	}
 	export interface JobThisType {
 	    document: JobDocument;
-	    replicate(config: Partial<JobConfig>): string | null;
+	    replicate(config: Partial<JobConfig>): Promise<string | null>;
 	    reschedule(config: Partial<JobConfig>): void;
 	    remove(): boolean;
 	    success(): void;

--- a/src/dominator.ts
+++ b/src/dominator.ts
@@ -48,7 +48,7 @@ class Dominator {
         private readonly configuration: DominatorConfiguration,
     ) {}
 
-    public initialize() {
+    public async initialize() {
         // Note: The `this.serverId` assignment is a race-condition based on `Meteor.startup(() => Dominator.initialize())`
         // TODO: Refactor Me! - Handle RAIC-style assignment of `this.serverId` with later refactor
         const packageConfiguration = Configuration.get();
@@ -62,7 +62,7 @@ class Dominator {
                 changed: (newPing) => this.observe(newPing),
             });
 
-        const lastPing = this.configuration.serverCollection.findOne();
+        const lastPing = await this.configuration.serverCollection.findOneAsync();
 
         const isLastPingOld = isPingOld(lastPing);
 
@@ -154,7 +154,7 @@ class Dominator {
         }
     }
 
-    private ping() {
+    private async ping() {
         const newPing = {
             date: new Date(),
             // TODO: Clean Me!
@@ -168,12 +168,12 @@ class Dominator {
             this.lastPing = newPing;
         }
 
-        this.configuration.serverCollection.upsert({ _id: DOMINATOR_ID }, newPing);
+        this.configuration.serverCollection.upsertAsync({ _id: DOMINATOR_ID }, newPing);
 
         Logger.log('Jobs', 'ping', newPing.date, 'paused:', newPing.pausedJobs);
     }
 
-    public start(jobArgument?: string | string[]) {
+    public async start(jobArgument?: string | string[]) {
         let upsertQuery: Mongo.Modifier<DominatorDocument> = {};
 
         if (jobArgument === null || jobArgument === undefined) {
@@ -191,12 +191,12 @@ class Dominator {
             // TODO: Implement Me!
         }
 
-        this.configuration.serverCollection.upsert({ _id: DOMINATOR_ID }, upsertQuery);
+        await this.configuration.serverCollection.upsertAsync({ _id: DOMINATOR_ID }, upsertQuery);
 
         Logger.log('Jobs', 'startJobs', jobArgument, upsertQuery);
     }
 
-    public stop(jobArgument?: string | string[]) {
+    public async stop(jobArgument?: string | string[]) {
         let upsertQuery: Mongo.Modifier<DominatorDocument> = {};
 
         if (jobArgument === null || jobArgument === undefined) {
@@ -212,7 +212,7 @@ class Dominator {
             // TODO: Implement Me!
         }
 
-        this.configuration.serverCollection.upsert({ _id: DOMINATOR_ID }, upsertQuery);
+        await this.configuration.serverCollection.upsertAsync({ _id: DOMINATOR_ID }, upsertQuery);
 
 		Logger.log('Jobs', 'stopJobs', jobArgument, upsertQuery);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@ import { Dominator } from './dominator';
 import { Jobs } from './job';
 import { Logger } from './logger';
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
     Logger.log('Jobs', `Meteor.startup, startupDelay: ${Configuration.get().startupDelay / 1000}s...`);
 
-    ServerCollection.remove({ _id: { $ne: DOMINATOR_ID } });
+    await ServerCollection.removeAsync({ _id: { $ne: DOMINATOR_ID } });
 
     Meteor.setTimeout(() => Dominator.initialize(), Configuration.get().startupDelay);
 });

--- a/src/job.ts
+++ b/src/job.ts
@@ -42,7 +42,7 @@ function getDateFromJobConfiguration(config: Partial<JobConfig>) {
                         console.warn('Jobs', `invalid type was input: {key1}.{key2}`, newNumber)
                     } else {
                         // convert month(s) => months (etc), and day(s) => date and year(s) => fullYear
-                        fn = (key2 + "s").replace('ss', 's').replace('days','date').replace('years','fullYear').replace('months','month');
+                        fn = (key2 + "s").replace('ss', 's').replace('days', 'date').replace('years', 'fullYear').replace('months', 'month');
                         // convert months => Months
                         fn = fn.charAt(0).toUpperCase() + fn.slice(1);
                         // if key1=='in' currentDate.setMonth(newNumber + currentDate.getMonth())
@@ -87,7 +87,7 @@ class JobsClass {
     // TODO: Rename `jobFunctionMap`
     public jobs: JobFunctionMap = {};
 
-    constructor(
+    constructor (
         private readonly configuration: JobConfiguration,
     ) {
         this.collection = this.configuration.jobCollection;
@@ -153,16 +153,16 @@ class JobsClass {
 
     public configure(settings: Partial<Config>) {
         // TODO: Review Me!
-		check(settings, {
-			autoStart: Match.Maybe(Boolean),
-			defaultCompletion: Match.Maybe(Match.Where((val => /^(success|remove)$/.test(val)))),
-		    error: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
-			log: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
-			warn: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
-			maxWait: Match.Maybe(Number),
-			setServerId: Match.Maybe(Match.OneOf(String, Function)),
-			startupDelay: Match.Maybe(Number),
-		});
+        check(settings, {
+            autoStart: Match.Maybe(Boolean),
+            defaultCompletion: Match.Maybe(Match.Where((val => /^(success|remove)$/.test(val)))),
+            error: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
+            log: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
+            warn: Match.Maybe(Match.OneOf(undefined, null, Boolean, Function)),
+            maxWait: Match.Maybe(Number),
+            setServerId: Match.Maybe(Match.OneOf(String, Function)),
+            startupDelay: Match.Maybe(Number),
+        });
 
         Configuration.configure(settings);
 
@@ -173,71 +173,71 @@ class JobsClass {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
-		const query: Mongo.Query<JobDocument> = {
-			name: jobName,
-		};
+        const query: Mongo.Query<JobDocument> = {
+            name: jobName,
+        };
 
         // TODO: Refactor into `reduce` ???
         parameters.forEach((parameter, index) => {
             query["arguments." + index] = parameter;
         });
 
-        return this.configuration.jobCollection.find(query).count();    
+        return this.configuration.jobCollection.find(query).count();
     }
 
     public countPending(jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
-		const query: Mongo.Query<JobDocument> = {
-			name: jobName,
+        const query: Mongo.Query<JobDocument> = {
+            name: jobName,
             state: 'pending',
-		};
+        };
 
         // TODO: Refactor into `reduce` ???
         parameters.forEach((parameter, index) => {
             query["arguments." + index] = parameter;
         });
-		
-        return this.configuration.jobCollection.find(query).count();
+
+        return this.configuration.jobCollection.find(query).countAsync();
     }
 
-    public execute(jobId: string) {
+    public async execute(jobId: string) {
         check(jobId, String);
 
         Logger.log('Jobs', 'Jobs.execute', jobId);
 
-        const job = this.configuration.jobCollection.findOne(jobId);
+        const job = await this.configuration.jobCollection.findOneAsync(jobId);
 
         if (!job) {
-			console.warn('Jobs', 'Jobs.execute', 'JOB NOT FOUND', jobId);
+            console.warn('Jobs', 'Jobs.execute', 'JOB NOT FOUND', jobId);
 
             return;
         }
 
         if (job.state != 'pending') {
-			console.warn('Jobs', 'Jobs.execute', 'JOB IS NOT PENDING', job);
+            console.warn('Jobs', 'Jobs.execute', 'JOB IS NOT PENDING', job);
             return;
         }
 
         Queue.executeJob(job);
     }
 
-	public findOne(jobName: string, ...parameters: any[]) {
-		check(jobName, String);
+    public async findOne(jobName: string, ...parameters: any[]) {
+        check(jobName, String);
         // TODO: Verify `parameters` ???
 
-		const query: Mongo.Query<JobDocument> = {
-			name: jobName,
-		};
+        const query: Mongo.Query<JobDocument> = {
+            name: jobName,
+        };
 
         // TODO: Refactor into `reduce` ???
         parameters.forEach((parameter, index) => {
             query["arguments." + index] = parameter;
         });
 
-        return this.configuration.jobCollection.findOne(query);
-	}
+        return await this.configuration.jobCollection.findOneAsync(query);
+    }
 
     public register(jobFunctionMap: JobFunctionMap) {
         // TODO: Verify Type! - `check(..., Object)` is not sufficient!
@@ -249,7 +249,7 @@ class JobsClass {
             jobFunctionMap,
         );
 
-		// log('Jobs', 'Jobs.register', Object.keys(jobs).length, Object.keys(newJobs).join(', '));
+        // log('Jobs', 'Jobs.register', Object.keys(jobs).length, Object.keys(newJobs).join(', '));
     }
 
     public remove(jobId: string) {
@@ -262,11 +262,11 @@ class JobsClass {
         return count > 0;
     }
 
-    public replicate(jobId: string, configuration: Partial<JobConfig>) {
+    public async replicate(jobId: string, configuration: Partial<JobConfig>) {
         check(jobId, String);
         // TODO: Verify `configuration`
 
-        const job = this.configuration.jobCollection.findOne(jobId);
+        const job = await this.configuration.jobCollection.findOneAsync(jobId);
 
         if (!job) {
             console.warn('Jobs', '    Jobs.replicate', 'JOB NOT FOUND', jobId);
@@ -285,16 +285,16 @@ class JobsClass {
         delete replicatedJob._id;
 
         // Create Job Document in Mongo...
-        const replicatedJobId = this.configuration.jobCollection.insert(replicatedJob);
+        const replicatedJobId = await this.configuration.jobCollection.insertAsync(replicatedJob);
 
         Logger.log('Jobs', '    Jobs.replicate', jobId, configuration);
 
         return replicatedJobId;
     }
 
-    public reschedule(jobId: string, configuration: Partial<JobConfig>) {
+    public async reschedule(jobId: string, configuration: Partial<JobConfig>) {
         check(jobId, String);
-        // TODO: Verify `configuration` 
+        // TODO: Verify `configuration`
 
         const update: Partial<JobDocument> = {
             due: getDateFromJobConfiguration(configuration),
@@ -304,7 +304,7 @@ class JobsClass {
         if (configuration.priority)
             update.priority = configuration.priority;
 
-        const count = this.configuration.jobCollection.update({ _id: jobId }, { $set: update });
+        const count = await this.configuration.jobCollection.updateAsync({ _id: jobId }, { $set: update });
 
         Logger.log('Jobs', '    Jobs.reschedule', jobId, configuration, update.due, count);
 
@@ -315,11 +315,11 @@ class JobsClass {
             configuration.callback(count === 0, count);
     }
 
-    public run(jobName: string, ...parameters: any[]) {
+    public async run(jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
-		Logger.log('Jobs', 'Jobs.run', jobName, parameters.length && parameters[0]);
+        Logger.log('Jobs', 'Jobs.run', jobName, parameters.length && parameters[0]);
 
         let configuration: null | Partial<JobConfig> = parameters[0] as Partial<JobConfig> || null;
 
@@ -338,10 +338,10 @@ class JobsClass {
         }
 
         // If a job is `singular`, only one can execute concurrently with the name name and arguments
-        // TODO: This should probably not be a thing... 
+        // TODO: This should probably not be a thing...
         //  One should be able to queue N jobs with a one-at-a-time execution limit
         if (configuration?.singular) {
-            if (this.countPending(jobName, parameters[1].slice()) > 0) {
+            if (await this.countPending(jobName, parameters[1]?.slice()) > 0) {
                 error = 'Singular job already exists';
             }
         }
@@ -363,10 +363,10 @@ class JobsClass {
             priority: configuration?.priority || 0,
             awaitAsync: configuration?.awaitAsync || undefined,
             due: (configuration) ? getDateFromJobConfiguration(configuration) : new Date(),
-            arguments: (configuration) ? parameters[1].slice() : parameters,
+            arguments: (configuration) ? parameters[1]?.slice() : parameters,
         };
 
-        const jobId = this.configuration.jobCollection.insert(job);
+        const jobId = await this.configuration.jobCollection.insertAsync(job);
 
         if (jobId) {
             job._id = jobId;

--- a/src/job.ts
+++ b/src/job.ts
@@ -19,7 +19,7 @@ import {
 
 // TODO: Review Me!
 // TODO: Test Me!
-function getDateFromJobConfiguration(config: Partial<JobConfig>) {
+function getDateFromJobConfiguration (config: Partial<JobConfig>) {
     // https://github.com/msavin/SteveJobs..meteor.jobs.scheduler.queue.background.tasks/blob/031fdf5051b2f2581a47f64ab5b54ffbb6893cf8/package/server/imports/utilities/helpers/date.js
     check(config, Match.ObjectIncluding({
         date: Match.Maybe(Date),
@@ -62,7 +62,7 @@ function getDateFromJobConfiguration(config: Partial<JobConfig>) {
 
 const jobConfigurationProperties: Array<keyof JobConfig> = ['in', 'on', 'priority', 'date', 'callback', 'singular', 'unique', 'awaitAsync']
 
-function isJobConfiguration(configuration: any) {
+function isJobConfiguration (configuration: any) {
     if (configuration !== null && configuration !== undefined) {
         if (typeof configuration === 'object') {
             // TODO: Should we be checking types here too... ???
@@ -93,7 +93,7 @@ class JobsClass {
         this.collection = this.configuration.jobCollection;
     }
 
-    public clear(state?: '*' | JobState | JobState[], jobName?: string, ...parameters: any[]) {
+    public async clear (state?: '*' | JobState | JobState[], jobName?: string, ...parameters: any[]) {
         const query: Mongo.Query<JobDocument> = {};
 
         // Add `state` Predicate to `query`
@@ -134,7 +134,7 @@ class JobsClass {
                 query['arguments.' + index] = parameter;
             });
 
-            const count = this.configuration.jobCollection.remove(query);
+            const count = await this.configuration.jobCollection.removeAsync(query);
 
             // TODO: Why `null` ???
             //  Compare with `reschedule` callback...
@@ -147,11 +147,11 @@ class JobsClass {
                 query['arguments.' + index] = parameter;
             });
 
-            return this.configuration.jobCollection.remove(query);
+            return await this.configuration.jobCollection.removeAsync(query);
         }
     }
 
-    public configure(settings: Partial<Config>) {
+    public configure (settings: Partial<Config>) {
         // TODO: Review Me!
         check(settings, {
             autoStart: Match.Maybe(Boolean),
@@ -169,7 +169,7 @@ class JobsClass {
         Logger.log('Jobs', 'Jobs.configure', Object.keys(settings));
     }
 
-    public count(jobName: string, ...parameters: any[]) {
+    public count (jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
@@ -185,7 +185,7 @@ class JobsClass {
         return this.configuration.jobCollection.find(query).count();
     }
 
-    public countPending(jobName: string, ...parameters: any[]) {
+    public countPending (jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
@@ -202,7 +202,7 @@ class JobsClass {
         return this.configuration.jobCollection.find(query).countAsync();
     }
 
-    public async execute(jobId: string) {
+    public async execute (jobId: string) {
         check(jobId, String);
 
         Logger.log('Jobs', 'Jobs.execute', jobId);
@@ -223,7 +223,7 @@ class JobsClass {
         Queue.executeJob(job);
     }
 
-    public async findOne(jobName: string, ...parameters: any[]) {
+    public async findOne (jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
@@ -239,7 +239,7 @@ class JobsClass {
         return await this.configuration.jobCollection.findOneAsync(query);
     }
 
-    public register(jobFunctionMap: JobFunctionMap) {
+    public register (jobFunctionMap: JobFunctionMap) {
         // TODO: Verify Type! - `check(..., Object)` is not sufficient!
         // check(newJobs, Object);
 
@@ -252,17 +252,17 @@ class JobsClass {
         // log('Jobs', 'Jobs.register', Object.keys(jobs).length, Object.keys(newJobs).join(', '));
     }
 
-    public remove(jobId: string) {
+    public async remove (jobId: string) {
         check(jobId, String);
 
-        var count = this.configuration.jobCollection.remove({ _id: jobId });
+        var count = await this.configuration.jobCollection.removeAsync({ _id: jobId });
 
         Logger.log('Jobs', `    Jobs.remove ${jobId}`, count);
 
         return count > 0;
     }
 
-    public async replicate(jobId: string, configuration: Partial<JobConfig>) {
+    public async replicate (jobId: string, configuration: Partial<JobConfig>) {
         check(jobId, String);
         // TODO: Verify `configuration`
 
@@ -292,7 +292,7 @@ class JobsClass {
         return replicatedJobId;
     }
 
-    public async reschedule(jobId: string, configuration: Partial<JobConfig>) {
+    public async reschedule (jobId: string, configuration: Partial<JobConfig>) {
         check(jobId, String);
         // TODO: Verify `configuration`
 
@@ -315,7 +315,7 @@ class JobsClass {
             configuration.callback(count === 0, count);
     }
 
-    public async run(jobName: string, ...parameters: any[]) {
+    public async run (jobName: string, ...parameters: any[]) {
         check(jobName, String);
         // TODO: Verify `parameters` ???
 
@@ -381,11 +381,11 @@ class JobsClass {
         return (error) ? false : job as JobDocument;
     }
 
-    public start(jobArgument?: string | string[]) {
+    public start (jobArgument?: string | string[]) {
         Dominator.start(jobArgument);
     }
 
-    public stop(jobArgument?: string | string[]) {
+    public stop (jobArgument?: string | string[]) {
         Dominator.stop(jobArgument);
     }
 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -80,7 +80,7 @@ interface JobConfiguration {
     jobCollection: Mongo.Collection<JobDocument>,
 }
 
-class Jobs {
+class JobsClass {
     // TODO: Refactor Away...
     public collection: Mongo.Collection<JobDocument>;
     // TODO: Refactor Away...
@@ -390,8 +390,8 @@ class Jobs {
     }
 }
 
-const instance = new Jobs({
+const Jobs = new JobsClass({
     jobCollection: JobCollection,
 });
 
-export { instance as Jobs };
+export { Jobs };

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface JobDocument {
 
 export interface JobThisType {
     document: JobDocument;
-    replicate(config: Partial<JobConfig>): string | null;
+    replicate(config: Partial<JobConfig>): Promise<string | null>;
     reschedule(config: Partial<JobConfig>): void;
     remove(): boolean;
     success(): void;


### PR DESCRIPTION
this PR updates the package to use all of the new async collection methods as well as fixes a minor issue where the generated types specified that the `Jobs` export was the class rather than the instance of the class.

Caveats:
This will need to wait to be published until V3 gets released unless you want to do an alpha release.
`api.versionsFrom()` will of course need to be updated. I have this running now in a 3.0-alpha.15 project but modifying versionsFrom will keep the version with new async methods from being installed in older Meteor projects.

Future considerations:
I think that a nice upgrade would be to `api.use`  `@zodern:types` to auto generate type definitions and include them in the installing app.